### PR TITLE
refactor (ci): adapt build jobs in all workflows to rely entirely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build job action

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -16,14 +16,7 @@ jobs:
         configurations: [Debug, Release]
         frameworks: [net8.0]
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
-      with:
-        name: github-nuget
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:
         configurations: ${{ matrix.configurations }}
         frameworks: ${{ matrix.frameworks }}

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -15,14 +15,7 @@ jobs:
         configurations: [Debug, Release]
         frameworks: [net8.0]
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
-      with:
-        name: github-nuget
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:
         configurations: ${{ matrix.configurations }}
         frameworks: ${{ matrix.frameworks }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,14 +14,7 @@ jobs:
         configurations: [Debug, Release]
         frameworks: [net8.0]
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
-      with:
-        name: github-nuget
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:
         configurations: ${{ matrix.configurations }}
         frameworks: ${{ matrix.frameworks }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,14 +15,7 @@ jobs:
         configurations: [Debug, Release]
         frameworks: [net8.0]
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
-      with:
-        name: github-nuget
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:
         configurations: ${{ matrix.configurations }}
         frameworks: ${{ matrix.frameworks }}


### PR DESCRIPTION
- **refactor (ci): adapt build-pr/build job to rely entirely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build job action**
- **refactor (ci): adapt build-ci/build job to rely entirely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build job action**
- **refactor (ci): adapt build-cron/build job to rely entirely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build job action**
- **refactor (ci): adapt publish/build job to rely entirely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build job action**
