### PR TITLE
refactor (ci): adapt all workflows test-nuget and nuget jobs to rely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack job action

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -57,24 +57,15 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
         username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
+      with:
+        configurations: Release
+        frameworks: |-
+          net8.0
+          netstandard2.1

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -38,27 +38,18 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
         username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
+      with:
+        configurations: Release
+        frameworks: |-
+          net8.0
+          netstandard2.1
 
 
   ### TODO: do not tag here, instead create a branch, update dependencies (dotnet )

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -60,27 +60,19 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
         username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
+      with:
+        configurations: Release
+        frameworks: |-
+          net8.0
+          netstandard2.1
+
 
   test-update-dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,30 +38,21 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
-    - id: nuget-pack
-      uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
         username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
+    - id: build-pack
+      uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack-publish@main
+      with:
+        configurations: Release
+        frameworks: |-
+          net8.0
+          netstandard2.1
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-publish@main
       with:
         registry: ${{ matrix.registry }}
         token: ${{ secrets[matrix.token] }}
-        packages: ${{ steps.nuget-pack.outputs.packages }}
+        packages: ${{ steps.build-pack.outputs.packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,8 @@ jobs:
     permissions:
       contents: write # allow GITHUB_TOKEN to create releases
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - uses: kagekirin/gha-dotnet/.github/actions/build@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
-    - id: nuget-pack
-      uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
+    - id: build-pack
+      uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
         configurations: Release
         frameworks: |-
@@ -32,6 +23,6 @@ jobs:
         title: Release ${{ github.action_ref }}
         generate-notes: true
         files: |
-          ${{ steps.nuget-pack.outputs.packages }}
+          ${{ steps.build-pack.outputs.packages }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- **refactor (ci): adapt build-pr/test-nuget job to rely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack job action**
- **refactor (ci): adapt build-ci/test-nuget job to rely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack job action**
- **refactor (ci): adapt build-cron/test-nuget job to rely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack job action**
- **refactor (ci): adapt publish/nuget job to rely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack job action**
- **refactor (ci): adapt release job to rely on kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack job action**
