### PR TITLE
refactor (ci): adapt workflows test-nuget and nuget jobs to call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -57,7 +57,7 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+    - uses: kagekirin/gha-py-toolbox/actions/dotnet/add-registry@main
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -38,7 +38,7 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+    - uses: kagekirin/gha-py-toolbox/actions/dotnet/add-registry@main
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -60,7 +60,7 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+    - uses: kagekirin/gha-py-toolbox/actions/dotnet/add-registry@main
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+    - uses: kagekirin/gha-py-toolbox/actions/dotnet/add-registry@main
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}


### PR DESCRIPTION
- **refactor (ci): adapt build-pr/test-nuget job to call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action**
- **refactor (ci): adapt build-ci/test-nuget job to call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action**
- **refactor (ci): adapt build-cron/test-nuget job to call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action**
- **refactor (ci): adapt publish/nuget job to call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action**
