### PR TITLE
refactor (ci): remove call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action from all workflows test-nuget and nuget jobs, as well as NuGet registry matrix parameters from all workflows test-nuget jobs

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -57,12 +57,6 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-py-toolbox/actions/dotnet/add-registry@main
-      with:
-        name: ${{ matrix.source }}
-        registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
-        token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
         configurations: Release

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -43,18 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
-    strategy:
-      matrix:
-        source: [nuget, github]
-        include:
-          - source: nuget
-            registry: https://api.nuget.org/v3/index.json
-            username: KageKirin
-            token: NUGET_ORG_TOKEN
-          - source: github
-            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-            username: ${{ github.repository_owner }}
-            token: GITHUB_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -24,18 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
-    strategy:
-      matrix:
-        source: [nuget, github]
-        include:
-          - source: nuget
-            registry: https://api.nuget.org/v3/index.json
-            username: KageKirin
-            token: NUGET_ORG_TOKEN
-          - source: github
-            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-            username: ${{ github.repository_owner }}
-            token: GITHUB_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -38,12 +38,6 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-py-toolbox/actions/dotnet/add-registry@main
-      with:
-        name: ${{ matrix.source }}
-        registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
-        token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
         configurations: Release

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -60,12 +60,6 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-py-toolbox/actions/dotnet/add-registry@main
-      with:
-        name: ${{ matrix.source }}
-        registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
-        token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
         configurations: Release

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -46,18 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
-    strategy:
-      matrix:
-        source: [nuget, github]
-        include:
-          - source: nuget
-            registry: https://api.nuget.org/v3/index.json
-            username: KageKirin
-            token: NUGET_ORG_TOKEN
-          - source: github
-            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-            username: ${{ github.repository_owner }}
-            token: GITHUB_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,12 +38,6 @@ jobs:
             token: GITHUB_TOKEN
     needs: build
     steps:
-    - uses: kagekirin/gha-py-toolbox/actions/dotnet/add-registry@main
-      with:
-        name: ${{ matrix.source }}
-        registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
-        token: ${{ secrets[matrix.token] }}
     - id: build-pack-publish
       uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack-publish@main
       with:


### PR DESCRIPTION
- **refactor (ci): remove call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action from build-pr/test-nuget job**
- **refactor (ci): remove call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action from build-ci/test-nuget job**
- **refactor (ci): remove call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action from build-cron/test-nuget job**
- **refactor (ci): remove call into kagekirin/gha-py-toolbox/actions/dotnet/add-registry action from publish/nuget job**
- **refactor (ci): remove NuGet registry matrix parameters from build-pr/test-nuget job**
- **refactor (ci): remove NuGet registry matrix parameters from build-ci/test-nuget job**
- **refactor (ci): remove NuGet registry matrix parameters from build-cron/test-nuget job**
