### PR TITLE
refactor (ci): change publish workflow triggering event to on-release-published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
-name: publish
+name: publish (nuget)
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   publish-nuget:


### PR DESCRIPTION
reason: improves chaining to release -> publish (nuget)
