### PR TITLE
feature (ci): implement publish-info workflow to print information about published packages

### DIFF
--- a/.github/workflows/publish-info.yml
+++ b/.github/workflows/publish-info.yml
@@ -1,0 +1,26 @@
+name: publish-info
+
+on:
+  registry_package:
+    types: [published]
+
+jobs:
+  info:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Show infos about published package
+      shell: python
+      env:
+        json: ${{ toJSON(github) }}
+      run: |-
+        """
+        ${{ toJSON(github) }}
+        """
+
+        import os, sys, json, pprint
+
+        jsondata = os.getenv('json')
+        print(jsondata)
+
+        data = json.loads(jsondata)
+        pprint.pp(data)


### PR DESCRIPTION
detail: this is mostly a test case for retrieving a downloadable package URL from the recently published package
