### PR TITLE
refactor (ci): adapt publish-info workflow to gh/download-published-nuget-package inputs change

### DIFF
--- a/.github/workflows/publish-info.yml
+++ b/.github/workflows/publish-info.yml
@@ -30,5 +30,5 @@ jobs:
       name: Download published package
       uses: kagekirin/gha-py-toolbox/actions/gh/download-published-nuget-package@main
       with:
-        registry_package: github.event.registry_package
+        registry_package_json: ${{ toJSON(github.event.registry_package) }}
         token: ${{ github.token }}


### PR DESCRIPTION
reason: figures you can't pass a GitHub data structure to an action variable without converting through JSON
