### PR TITLE
refactor (ci): move release package upload from release workflow to publish-info workflow

### DIFF
--- a/.github/workflows/publish-info.yml
+++ b/.github/workflows/publish-info.yml
@@ -8,6 +8,7 @@ jobs:
   info:
     permissions:
       packages: read
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Install dependencies
@@ -32,3 +33,10 @@ jobs:
       with:
         registry_package_json: ${{ toJSON(github.event.registry_package) }}
         token: ${{ github.token }}
+
+    - id: updload-assets
+      uses: kagekirin/gha-py-toolbox/actions/gh/upload-release-assets@main
+      with:
+        token: ${{ github.token }}
+        tag: v${{ github.event.registry_package.package_version.version }}
+        files: ${{ steps.download-package.outputs.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,27 +11,11 @@ jobs:
     permissions:
       contents: write # allow GITHUB_TOKEN to create releases
     steps:
-    - id: build-pack
-      uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
-      with:
-        configurations: Release
-        frameworks: |-
-          net8.0
-          netstandard2.1
     - id: create-release
       uses: kagekirin/gha-py-toolbox/actions/gh/create-release@main
       with:
         token: ${{ secrets.GH_RELEASE_TOKEN }}
-        title: Release ${{ github.ref_name }}
+        title: Release ${{ github.event.ref }}
         generate-notes: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
-    - id: updload-assets
-      uses: kagekirin/gha-py-toolbox/actions/gh/upload-release-assets@main
-      with:
-        token: ${{ secrets.GH_RELEASE_TOKEN }}
-        tag: ${{ github.ref_name }}
-        files: |
-          ${{ steps.build-pack.outputs.packages }}
       env:
         GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
- **refactor (ci): remove NuGet package creation and uploaded from release workflow**
  i.e. simplify release workflow to only create release
  

- **refactor (ci): adapt publish-info workflow to upload downloaded NuGet package to matching release**
  