### PR TITLE
fix (ci): use correct variable names in release and publish-info workflows

### DIFF
--- a/.github/workflows/publish-info.yml
+++ b/.github/workflows/publish-info.yml
@@ -27,16 +27,16 @@ jobs:
         ${{ toJSON(github) }}
         """
 
-    - id: download-package
+    - id: download-packages
       name: Download published package
       uses: kagekirin/gha-py-toolbox/actions/gh/download-published-nuget-package@main
       with:
         registry_package_json: ${{ toJSON(github.event.registry_package) }}
         token: ${{ github.token }}
 
-    - id: updload-assets
+    - id: upload-assets
       uses: kagekirin/gha-py-toolbox/actions/gh/upload-release-assets@main
       with:
         token: ${{ github.token }}
         tag: v${{ github.event.registry_package.package_version.version }}
-        files: ${{ steps.download-package.outputs.package }}
+        files: ${{ steps.download-packages.outputs.packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: kagekirin/gha-py-toolbox/actions/gh/create-release@main
       with:
         token: ${{ secrets.GH_RELEASE_TOKEN }}
-        title: Release ${{ github.event.ref }}
+        title: Release ${{ github.ref_name }}
         generate-notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
- **fix (ci): use correct github.ref_name as release name**
- **fix (ci): use correct outputs variable name in publish-info workflow**
