### PR TITLE
refactor (ci): move published package release upload to separate workflow

### DIFF
--- a/.github/workflows/publish-info.yml
+++ b/.github/workflows/publish-info.yml
@@ -1,4 +1,4 @@
-name: publish-info
+name: Print info about published package
 
 on:
   registry_package:
@@ -6,37 +6,19 @@ on:
 
 jobs:
   info:
-    permissions:
-      packages: read
-      contents: write
     runs-on: ubuntu-latest
     steps:
-    - name: Install dependencies
-      uses: kagekirin/gha-py-toolbox/actions/pip/install@main
+    - name: Show infos about GitHub
+      uses: kagekirin/gha-py-toolbox/actions/util/display-json-object@main
       with:
-        packages: >-
-          PyGithub
-          requests
+        object: ${{ toJSON(github) }}
 
-    - name: Show infos about published package
-      shell: python
-      env:
-        json: ${{ toJSON(github) }}
-      run: |-
-        """
-        ${{ toJSON(github) }}
-        """
-
-    - id: download-packages
-      name: Download published package
-      uses: kagekirin/gha-py-toolbox/actions/gh/download-published-nuget-package@main
+    - name: Show infos about event
+      uses: kagekirin/gha-py-toolbox/actions/util/display-json-object@main
       with:
-        registry_package_json: ${{ toJSON(github.event.registry_package) }}
-        token: ${{ github.token }}
+        object: ${{ toJSON(github.event) }}
 
-    - id: upload-assets
-      uses: kagekirin/gha-py-toolbox/actions/gh/upload-release-assets@main
+    - name: Show infos about registry package
+      uses: kagekirin/gha-py-toolbox/actions/util/display-json-object@main
       with:
-        token: ${{ github.token }}
-        tag: v${{ github.event.registry_package.package_version.version }}
-        files: ${{ steps.download-packages.outputs.packages }}
+        object: ${{ toJSON(github.event.registry_package) }}

--- a/.github/workflows/release-published-packages.yml
+++ b/.github/workflows/release-published-packages.yml
@@ -1,0 +1,26 @@
+name: Release published package
+
+on:
+  registry_package:
+    types: [published]
+
+jobs:
+  info:
+    permissions:
+      packages: read
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - id: download-packages
+      name: Download published package
+      uses: kagekirin/gha-py-toolbox/actions/gh/download-published-nuget-package@main
+      with:
+        registry_package_json: ${{ toJSON(github.event.registry_package) }}
+        token: ${{ github.token }}
+
+    - id: upload-assets
+      uses: kagekirin/gha-py-toolbox/actions/gh/upload-release-assets@main
+      with:
+        token: ${{ github.token }}
+        tag: v${{ github.event.registry_package.package_version.version }}
+        files: ${{ steps.download-packages.outputs.packages }}


### PR DESCRIPTION
- **feature (ci): implement release-published-packages workflow**
  implementation moved from publish-info workflow
  

- **refactor (ci): reduce publish-info workflow to only displaying information about published package**
  