### PR TITLE
refactor (ci): replace call to internal jobactions/tag with call to kagekirin/gha-py-toolbox dotnet/checkout-bump-tag job macro

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -26,17 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-bump-tag@main
       with:
-        ssh-key: "${{ secrets.DEPLOY_KEY }}"
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - id: create-tag
-      uses: ./.github/jobactions/tag
-    - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
-      with:
-        remote: origin
-        branch: main
+        ssh-key: "${{secrets.DEPLOY_KEY}}"
+        name: 'GitHub CI on behalf of ${{ github.actor }}'
+        commit-message: 'build (ci): update to version'
+        tag-message: ''
         dry-run: false
 
   pack-nuget:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,24 +22,13 @@ jobs:
   test-tag:
     runs-on: ubuntu-latest
     needs: build
-    permissions:
-      packages: read
     steps:
-    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
+    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-bump-tag@main
       with:
         ssh-key: "${{secrets.DEPLOY_KEY}}"
-    - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
-    - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-    - id: create-tag
-      uses: ./.github/jobactions/tag
-    - shell: pwsh
-      run: |-
-        echo "new version: ${{ steps.create-tag.outputs.version }}"
-    - if: ${{ ! endsWith(github.ref_name, 'merge') }}
-      uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
-      with:
-        remote: origin
-        branch: ${{ github.head_ref || github.ref_name }}
+        commit-message: 'build (ci): update to version'
+        name: 'GitHub CI on behalf of ${{ github.actor }}'
+        tag-message: ''
         dry-run: true
 
   pack-nuget:


### PR DESCRIPTION
- **refactor (ci): replace call to internal jobactions/tag with call to kagekirin/gha-py-toolbox dotnet/checkout-bump-tag job macro in build-pr workflow**
- **refactor (ci): replace call to internal jobactions/tag with call to kagekirin/gha-py-toolbox dotnet/checkout-bump-tag job macro in build-ci workflow**
