### PR TITLE
refactor (ci): replace call to kagekirin/gha-py-toolbox dotnet/checkout-bump-tag job macro with call to kagekirin/gha-py-toolbox/jobs/git/checkout-bump-tag

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-bump-tag@main
+    - uses: kagekirin/gha-py-toolbox/jobs/git/checkout-bump-tag@main
       with:
         ssh-key: "${{secrets.DEPLOY_KEY}}"
         name: 'GitHub CI on behalf of ${{ github.actor }}'
-        commit-message: 'build (ci): update to version'
-        tag-message: ''
+        message: 'build (ci): update to version'
+        bump_patch: true
         dry-run: false
 
   pack-nuget:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-bump-tag@main
+    - uses: kagekirin/gha-py-toolbox/jobs/git/checkout-bump-tag@main
       with:
         ssh-key: "${{secrets.DEPLOY_KEY}}"
-        commit-message: 'build (ci): update to version'
+        message: 'build (ci): update to version'
         name: 'GitHub CI on behalf of ${{ github.actor }}'
-        tag-message: ''
+        bump_patch: true
         dry-run: true
 
   pack-nuget:


### PR DESCRIPTION
- **refactor (ci): replace call to kagekirin/gha-py-toolbox dotnet/checkout-bump-tag job macro with call to kagekirin/gha-py-toolbox/jobs/git/checkout-bump-tag for build-pr/test-tag job**
- **refactor (ci): replace call to kagekirin/gha-py-toolbox dotnet/checkout-bump-tag job macro with call to kagekirin/gha-py-toolbox/jobs/git/checkout-bump-tag for build-ci/tag job**
