### PR TITLE
build (Keillogs): set assembly version metadata from git tag via MinVer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,6 +45,10 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
+  <PropertyGroup Label="MinVer configuration">
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
+
   <ItemGroup Label="packaged files">
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="\" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,6 +56,8 @@
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
     <!-- enable source link -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+     <!-- enable automatic versioning -->
+    <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup Label="source link settings">

--- a/Keillogs/Keillogs.csproj
+++ b/Keillogs/Keillogs.csproj
@@ -6,13 +6,6 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
-  <!-- version metadata -->
-  <PropertyGroup>
-    <Version>0.0.35</Version>
-    <AssemblyVersion>0.0.35.36</AssemblyVersion>
-    <FileVersion>0.0.35.36</FileVersion>
-  </PropertyGroup>
-
   <!-- build metadata -->
   <PropertyGroup>
     <Title>Keillogs</Title>


### PR DESCRIPTION
- **build (props): add global dependency on MinVer v5.0.0**
- **build (props): configure MinVer tag prefix**
- **build (Keillogs): remove version metadata from project file**
