### PR TITLE
refactor (ci): use environment variables as job parameters

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
-        frameworks: [net9.0]
+        frameworks: ${{ fromJson(vars.FRAMEWORKS) }}
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
         frameworks: ${{ fromJson(vars.FRAMEWORKS) }}
+        include: ${{ fromJson(vars.BUILD_MATRIX) }}
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -12,7 +12,7 @@ jobs:
       packages: read
     strategy:
       matrix:
-        configurations: [Debug, Release]
+        configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
         frameworks: [net9.0]
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
-        frameworks: [net9.0]
+        frameworks: ${{ fromJson(vars.FRAMEWORKS) }}
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -44,6 +44,4 @@ jobs:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
         configurations: ${{ join(fromJson(vars.DEPLOY_CONFIGURATIONS), ' ') }}
-        frameworks: |-
-          net9.0
-          netstandard2.1
+        frameworks: ${{ join(fromJson(vars.DEPLOY_FRAMEWORKS), ' ') }}

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -13,7 +13,7 @@ jobs:
       packages: read
     strategy:
       matrix:
-        configurations: [Debug, Release]
+        configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
         frameworks: [net9.0]
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
         frameworks: ${{ fromJson(vars.FRAMEWORKS) }}
+        include: ${{ fromJson(vars.BUILD_MATRIX) }}
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
-        configurations: Release
+        configurations: ${{ join(fromJson(vars.DEPLOY_CONFIGURATIONS), ' ') }}
         frameworks: |-
           net9.0
           netstandard2.1

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
-        frameworks: [net9.0]
+        frameworks: ${{ fromJson(vars.FRAMEWORKS) }}
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
         frameworks: ${{ fromJson(vars.FRAMEWORKS) }}
+        include: ${{ fromJson(vars.BUILD_MATRIX) }}
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -12,7 +12,7 @@ jobs:
       packages: read
     strategy:
       matrix:
-        configurations: [Debug, Release]
+        configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
         frameworks: [net9.0]
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
-        configurations: Release
+        configurations: ${{ join(fromJson(vars.DEPLOY_CONFIGURATIONS), ' ') }}
         frameworks: |-
           net9.0
           netstandard2.1

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -30,9 +30,7 @@ jobs:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
         configurations: ${{ join(fromJson(vars.DEPLOY_CONFIGURATIONS), ' ') }}
-        frameworks: |-
-          net9.0
-          netstandard2.1
+        frameworks: ${{ join(fromJson(vars.DEPLOY_FRAMEWORKS), ' ') }}
 
 
   ### TODO: do not tag here, instead create a branch, update dependencies (dotnet )

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -41,9 +41,7 @@ jobs:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
         configurations: ${{ join(fromJson(vars.DEPLOY_CONFIGURATIONS), ' ') }}
-        frameworks: |-
-          net9.0
-          netstandard2.1
+        frameworks: ${{ join(fromJson(vars.DEPLOY_FRAMEWORKS), ' ') }}
 
 
   test-update-dependencies:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
         frameworks: ${{ fromJson(vars.FRAMEWORKS) }}
+        include: ${{ fromJson(vars.BUILD_MATRIX) }}
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack@main
       with:
-        configurations: Release
+        configurations: ${{ join(fromJson(vars.DEPLOY_CONFIGURATIONS), ' ') }}
         frameworks: |-
           net9.0
           netstandard2.1

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,7 +11,7 @@ jobs:
       packages: read
     strategy:
       matrix:
-        configurations: [Debug, Release]
+        configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
         frameworks: [net9.0]
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         configurations: ${{ fromJson(vars.CONFIGURATIONS) }}
-        frameworks: [net9.0]
+        frameworks: ${{ fromJson(vars.FRAMEWORKS) }}
     steps:
     - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
       with:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -12,15 +12,7 @@ jobs:
     strategy:
       matrix:
         source: ${{ fromJson(vars.DEPLOY_SOURCES) }}
-        include:
-          - source: nuget
-            registry: https://api.nuget.org/v3/index.json
-            username: KageKirin
-            token: NUGET_ORG_TOKEN
-          - source: github
-            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-            username: ${{ github.repository_owner }}
-            token: GH_PUBLISH_TOKEN
+        include: ${{ fromJson(vars.DEPLOY_MATRIX) }}
     steps:
     - id: build-pack-publish
       uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack-publish@main

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -26,8 +26,6 @@ jobs:
       uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack-publish@main
       with:
         configurations: ${{ join(fromJson(vars.DEPLOY_CONFIGURATIONS), ' ') }}
-        frameworks: |-
-          net9.0
-          netstandard2.1
+        frameworks: ${{ join(fromJson(vars.DEPLOY_FRAMEWORKS), ' ') }}
         registry: ${{ matrix.registry }}
         nuget-token: ${{ secrets[matrix.token] }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -25,7 +25,7 @@ jobs:
     - id: build-pack-publish
       uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build-pack-publish@main
       with:
-        configurations: Release
+        configurations: ${{ join(fromJson(vars.DEPLOY_CONFIGURATIONS), ' ') }}
         frameworks: |-
           net9.0
           netstandard2.1

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [nuget, github]
+        source: ${{ fromJson(vars.DEPLOY_SOURCES) }}
         include:
           - source: nuget
             registry: https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        amalgamate: [true, false]
+        amalgamate: ${{ fromJson(vars.UPM_AMALGAMATE) }}
         target: [npmjs, github]
         include:
           - target: npmjs

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         amalgamate: ${{ fromJson(vars.UPM_AMALGAMATE) }}
-        target: [npmjs, github]
+        target: ${{ fromJson(vars.UPM_TARGETS) }}
         include:
           - target: npmjs
             registry: https://api.npmjs.org/v3/index.json

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -13,15 +13,7 @@ jobs:
       matrix:
         amalgamate: ${{ fromJson(vars.UPM_AMALGAMATE) }}
         target: ${{ fromJson(vars.UPM_TARGETS) }}
-        include:
-          - target: npmjs
-            registry: https://api.npmjs.org/v3/index.json
-            username: KageKirin
-            token: NPMJS_ORG_TOKEN
-          - target: github
-            registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-            username: ${{ github.repository_owner }}
-            token: GH_PUBLISH_TOKEN
+        include: ${{ fromJson(vars.UPM_MATRIX) }}
     steps:
     - uses: actions/checkout@v4
     - id: nugettier-install

--- a/.github/workflows/vars_README.md
+++ b/.github/workflows/vars_README.md
@@ -1,0 +1,124 @@
+# Repository-wide Variables to set up
+
+In order to be DRY-compliant, the following variables must be set.
+Each variable is a **JSON**-representation of the regular YAML arrays/dicts
+and must be converted back using the intrinsic `fromJson()` method.
+
+## Variables used by build actions/macros
+
+These are the variables to set up to be passed to build actions/macros, i.e.
+
+- `build-branch`
+- `build-pr`
+- `build-tag`
+- `build-ci`
+- `build-cron`
+
+```yaml
+CONFIGURATIONS: ["Debug", "Release"]
+FRAMEWORKS: ["net9.0", "netstandard2.1"]
+BUILD_MATRIX: |-
+  [
+    {
+      "framework": "net9.0",
+      "projects": "Keillogs.net9.0.slnf"
+    },
+    {
+      "framework": "netstandard2.1",
+      "projects": "Keillogs.netstandard2.1.slnf"
+    }
+  ]
+```
+
+## Variables used by unittest actions/macros
+
+These are the variables to set up to be passed to unit test actions/macros, i.e.
+
+- `build-branch`
+- `build-pr`
+- `build-tag`
+- `build-ci`
+- `build-cron`
+
+```yaml
+TEST_FRAMEWORKS: ["net9.0"]
+TEST_MATRIX: |-
+  [
+    {
+      "framework": "net9.0",
+      "projects": "Keillogs.net9.0.Tests.slnf"
+    }
+  ]
+```
+
+## Variables used by nuget-pack and nuget-publish actions/macros
+
+These are the variables to set up to be passed to nuget-pack and nuget-publish actions/macros, i.e.
+
+- `build-branch`
+- `build-pr`
+- `build-tag`
+- `build-ci`
+- `build-cron`
+- `publish-nuget`
+
+```yaml
+DEPLOY_PROJECTS: ["Keillogs.sln"]
+DEPLOY_CONFIGURATIONS: ["Release"]
+DEPLOY_FRAMEWORKS: [""] ## yes, left empty
+```
+
+## Variables used by nuget-publish actions/macros
+
+These are the variables to set up to be passed to nuget-publish actions/macros, i.e.
+
+- `publish-nuget`
+
+```yaml
+DEPLOY_SOURCES: ["github", "nuget"]
+DEPLOY_MATRIX: |-
+  [
+    {
+      "source": "github",
+      "registry": "https://nuget.pkg.github.com/$GITHUB_REPOSITORY_OWNER/index.json",
+      "username": "$GITHUB_REPOSITORY_OWNER",
+      "token": "GH_PACKAGE_TOKEN"
+    },
+    {
+      "source": "nuget",
+      "registry": "https://api.nuget.org/v3/index.json",
+      "username": "$GITHUB_REPOSITORY_OWNER",
+      "token": "NUGET_ORG_TOKEN"
+    }
+  ]
+```
+
+## Variables used by upm-publish actions/macros
+
+These are the variables to set up to be passed to upm-publish actions/macros, i.e.
+
+- `publish-upm`
+
+```yaml
+UPM_AMALGAMATE: ["false", "true"]
+UPM_TARGETS: ["github", "npmjs", "gcp-my-upm"]
+UPM_MATRIX: |-
+  [
+    {
+      "target": "github",
+      "registry": "https://npm.pkg.github.com/@$GITHUB_REPOSITORY_OWNER",
+      "token": "GH_PACKAGE_TOKEN"
+    },
+    {
+      "target": "npmjs",
+      "registry": "https://registry.npmjs.org",
+      "token": "NPMJS_ORG_TOKEN"
+    },
+    {
+      "target": "gcp-my-upm",
+      "registry": "https://region-npm.pkg.dev/my/upm/",
+      "token": "GITHUB_TOKEN",
+      "credentials-json": "GCP_CREDENTIALS_JSON"
+    }
+  ]
+```


### PR DESCRIPTION
- **refactor (ci): use environment variable `vars.CONFIGURATIONS` as matrix.configurations parameter for build-branch/build job**
- **refactor (ci): use environment variable `vars.CONFIGURATIONS` as matrix.configurations parameter for build-ci/build job**
- **refactor (ci): use environment variable `vars.CONFIGURATIONS` as matrix.configurations parameter for build-cron/build job**
- **refactor (ci): use environment variable `vars.CONFIGURATIONS` as matrix.configurations parameter for build-pr/build job**
- **refactor (ci): use environment variable `vars.FRAMEWORKS` as matrix.frameworks parameter for build-branch/build job**
- **refactor (ci): use environment variable `vars.FRAMEWORKS` as matrix.frameworks parameter for build-ci/build job**
- **refactor (ci): use environment variable `vars.FRAMEWORKS` as matrix.frameworks parameter for build-cron/build job**
- **refactor (ci): use environment variable `vars.FRAMEWORKS` as matrix.frameworks parameter for build-pr/build job**
- **refactor (ci): use environment variable `vars.BUILD_MATRIX` as matrix.include parameter for build-branch/build job**
- **refactor (ci): use environment variable `vars.BUILD_MATRIX` as matrix.include parameter for build-ci/build job**
- **refactor (ci): use environment variable `vars.BUILD_MATRIX` as matrix.include parameter for build-cron/build job**
- **refactor (ci): use environment variable `vars.BUILD_MATRIX` as matrix.include parameter for build-pr/build job**
- **refactor (ci): use environment variable `vars.DEPLOY_CONFIGURATIONS` as configurations parameter for build-ci/pack-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_CONFIGURATIONS` as configurations parameter for build-cron/pack-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_CONFIGURATIONS` as configurations parameter for build-pr/pack-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_CONFIGURATIONS` as configurations parameter for publish-nuget/publish-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_FRAMEWORKS` as frameworks parameter for build-ci/pack-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_FRAMEWORKS` as frameworks parameter for build-cron/pack-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_FRAMEWORKS` as frameworks parameter for build-pr/pack-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_FRAMEWORKS` as frameworks parameter for publish-nuget/publish-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_SOURCES` as matrix.source parameter for publish-nuget/publish-nuget job**
- **refactor (ci): use environment variable `vars.DEPLOY_MATRIX` as matrix.include parameter for publish-nuget/publish-nuget job**
- **refactor (ci): use environment variable `vars.UPM_AMALGAMATE` as matrix.amalgamate parameter for publish-upm/publish-upm job**
- **refactor (ci): use environment variable `vars.UPM_TARGETS` as matrix.target parameter for publish-upm/publish-upm job**
- **refactor (ci): use environment variable `vars.UPM_MATRIX` as matrix.include parameter for publish-upm/publish-upm job**
- **doc (ci): document format and data to set for CI environment variables**
