### PR TITLE
feature (ci): add unique concurrency groups to workflows

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -5,6 +5,10 @@ on:
     branches-ignore:
       - 'main'
 
+concurrency:
+  group: ${{ github.actor_id }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
     types: [closed]
 
+concurrency:
+  group: ${{ github.actor_id }}-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.actor_id }}-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.actor_id }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.actor_id }}-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -4,6 +4,10 @@ on:
   registry_package:
     types: [published]
 
+concurrency:
+  group: ${{ github.actor_id }}-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}-${{ github.event.registry_package.name }}-${{ github.event.registry_package.package_version.name }}-${{ github.event.registry_package.id }}
+  cancel-in-progress: true
+
 jobs:
   publish-upm:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -4,6 +4,10 @@ on:
   registry_package:
     types: [published]
 
+concurrency:
+  group: ${{ github.actor_id }}-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   info:
     permissions:


### PR DESCRIPTION
- **feature (ci): add concurrency group to build-branch workflow**
- **feature (ci): add concurrency group to build-ci workflow**
- **feature (ci): add concurrency group to build-cron workflow**
- **feature (ci): add concurrency group to build-pr workflow**
- **feature (ci): add concurrency group to publish-nuget workflow**
- **feature (ci): add concurrency group to publish-upm workflow**
- **feature (ci): add concurrency group to release-published workflow**
