### PR TITLE
build: enable central package version management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,11 +56,6 @@
     <None Include="$(MSBuildThisFileDirectory)CHANGELOG.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <ItemGroup Label="package dependencies">
-    <!-- enable automatic versioning -->
-    <PackageReference Include="MinVer" PrivateAssets="All"/>
-  </ItemGroup>
-
   <ItemGroup Label="source link settings">
     <SourceLinkGitHubHost Include="github.com" ContentUrl="https://raw.github.com" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,8 +57,6 @@
   </ItemGroup>
 
   <ItemGroup Label="package dependencies">
-    <!-- enable reproducible builds -->
-    <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
     <!-- enable source link -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <!-- enable automatic versioning -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,8 +57,6 @@
   </ItemGroup>
 
   <ItemGroup Label="package dependencies">
-    <!-- enable source link -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <!-- enable automatic versioning -->
     <PackageReference Include="MinVer" PrivateAssets="All"/>
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -60,7 +60,7 @@
     <!-- enable reproducible builds -->
     <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
     <!-- enable source link -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <!-- enable automatic versioning -->
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All"/>
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,7 +62,7 @@
     <!-- enable source link -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <!-- enable automatic versioning -->
-    <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All"/>
+    <PackageReference Include="MinVer" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup Label="source link settings">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,7 +58,7 @@
 
   <ItemGroup Label="package dependencies">
     <!-- enable reproducible builds -->
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
     <!-- enable source link -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <!-- enable automatic versioning -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <ArtifactsPath>$(MSBuildThisFileDirectory).artifacts</ArtifactsPath>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <PropertyGroup Label="publishing settings">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,6 @@
+<Project>
+
+  <ItemGroup Label="build dependencies">
+  </ItemGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
 
   <ItemGroup Label="build dependencies">
+    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
   </ItemGroup>
 
   <ItemGroup Label="nuget dependencies">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
   <ItemGroup Label="nuget dependencies">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,4 +3,7 @@
   <ItemGroup Label="build dependencies">
   </ItemGroup>
 
+  <ItemGroup Label="nuget dependencies">
+  </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
   </ItemGroup>
 
   <ItemGroup Label="nuget dependencies">
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,8 @@
   <ItemGroup Label="global package references">
     <!-- enable reproducible builds -->
     <GlobalPackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
+    <!-- enable source link -->
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,8 @@
   </ItemGroup>
 
   <ItemGroup Label="global package references">
+    <!-- enable reproducible builds -->
+    <GlobalPackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="xunit" Version="2.6.6" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
 
   <ItemGroup Label="nuget dependencies">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,4 +6,7 @@
   <ItemGroup Label="nuget dependencies">
   </ItemGroup>
 
+  <ItemGroup Label="global package references">
+  </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,8 @@
     <GlobalPackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
     <!-- enable source link -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <!-- enable automatic versioning -->
+    <GlobalPackageReference Include="MinVer" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="xunit" Version="2.6.6" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
 
   <ItemGroup Label="build dependencies">
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="nuget dependencies">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="xunit" Version="2.6.6" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
   <ItemGroup Label="build dependencies">
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="MinVer" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="nuget dependencies">

--- a/Keillogs/Keillogs.csproj
+++ b/Keillogs/Keillogs.csproj
@@ -22,7 +22,7 @@
 
   <!-- package dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
   </ItemGroup>
 
 </Project>

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <PackageReference Include="xunit" Version="2.6.6"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit" Version="2.6.6"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <PackageReference Include="xunit" Version="2.6.6"/>

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -8,7 +8,7 @@
 
   <!-- package dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="xunit" Version="2.6.6"/>
+    <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>

--- a/Tests/Functionality/Functionality.csproj
+++ b/Tests/Functionality/Functionality.csproj
@@ -9,7 +9,7 @@
   <!-- package dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>


### PR DESCRIPTION
- **build (Directory.Packages.props): add ItemGroup for Package Versions pertaining to build dependencies**
- **build (Directory.Packages.props): add ItemGroup for Package Versions pertaining to nuget dependencies**
- **build (Directory.Packages.props): add ItemGroup for Global Package References**
- **build (Directory.Packages.props): add Package Version for DotNet.ReproducibleBuilds v1.2.25**
- **build (Directory.Packages.props): add Package Version for Microsoft.SourceLink.GitHub v8.0.0**
- **build (Directory.Packages.props): add Package Version for MinVer v6.0.0**
- **build (Directory.Packages.props): add Package Version for Microsoft.Extensions.Logging v8.0.0**
- **build (Directory.Packages.props): add Package Version for Microsoft.Extensions.Logging.Abstractions v8.0.0**
- **build (Directory.Packages.props): add Package Version for Microsoft.Extensions.Logging.Configuration v8.0.0**
- **build (Directory.Packages.props): add Package Version for Microsoft.Extensions.Logging.Console v8.0.0**
- **build (Directory.Packages.props): add Package Version for Microsoft.Extensions.Logging.Debug v8.0.0**
- **build (Directory.Packages.props): add Package Version for Microsoft.NET.Test.Sdk v17.8.0**
- **build (Directory.Packages.props): add Package Version for xunit v2.6.6**
- **build (Directory.Packages.props): add Package Version for xunit.runner.visualstudio v2.5.6**
- **build (Directory.Packages.props): add Package Version for coverlet.collector v6.0.0**
- **build (Directory.Packages.props): add Global Package Reference for DotNet.ReproducibleBuilds**
- **build (Directory.Packages.props): add Global Package Reference for Microsoft.SourceLink.GitHub**
- **build (Directory.Packages.props): add Global Package Reference for MinVer**
- **build (Directory.Build.props): remove Version attribute from Package Reference for DotNet.ReproducibleBuilds**
- **build (Directory.Build.props): remove Version attribute from Package Reference for Microsoft.SourceLink.GitHub**
- **build (Directory.Build.props): remove Version attribute from Package Reference for MinVer**
- **build (Keillogs): remove Version attribute from Package Reference for Microsoft.Extensions.Logging**
- **build (UnitTests): remove Version attribute from Package Reference for Microsoft.Extensions.Logging**
- **build (UnitTests): remove Version attribute from Package Reference for Microsoft.Extensions.Logging.Abstractions**
- **build (UnitTests): remove Version attribute from Package Reference for Microsoft.Extensions.Logging.Configuration**
- **build (UnitTests): remove Version attribute from Package Reference for Microsoft.Extensions.Logging.Console**
- **build (UnitTests): remove Version attribute from Package Reference for Microsoft.Extensions.Logging.Debug**
- **build (UnitTests): remove Version attribute from Package Reference for Microsoft.NET.Test.Sdk**
- **build (UnitTests): remove Version attribute from Package Reference for xunit**
- **build (UnitTests): remove Version attribute from Package Reference for xunit.runner.visualstudio**
- **build (UnitTests): remove Version attribute from Package Reference for coverlet.collector**
- **build (Directory.Build.props): remove Package Reference to DotNet.ReproducibleBuilds**
- **build (Directory.Build.props): remove Package Reference to Microsoft.SourceLink.GitHub**
- **build (Directory.Build.props): remove Package Reference to MinVer**
- **build (Directory.Build.props): enable central package version management**
