### PR TITLE
fix (NuGet.config): remove BOM

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
     <add key="repositoryPath" value=".nuget" />


### PR DESCRIPTION
reason: Python 'utf-8' incompatibility.
